### PR TITLE
fix: enforce correct certificate permissions after copy

### DIFF
--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=trustusercerts
 name=Always Trust User Certificates
-version=v0.4.1
-versionCode=41
+version=v0.4.2
+versionCode=42
 author=Jeroen Beckers (NVISO.eu)
 description=This module adds all installed user certificates to the system trust store.
 minMagisk=2400

--- a/post-fs-data.sh
+++ b/post-fs-data.sh
@@ -6,6 +6,7 @@ MODDIR=${0%/*}
 mkdir -p $MODDIR/system/etc/security/cacerts
 rm $MODDIR/system/etc/security/cacerts/*
 cp -f /data/misc/user/0/cacerts-added/* $MODDIR/system/etc/security/cacerts/
+set_perm_recursive $MODDIR/system/etc/security/cacerts/ root root 644
 
 # This script will be executed in post-fs-data mode
 # More info in the main Magisk thread


### PR DESCRIPTION
Set the permissions of the certificate copied across to the system
folder so ordinary users can see the certificate.